### PR TITLE
Add 192.168.*.* to the default bypass list

### DIFF
--- a/omega-target-chromium-extension/src/module/upgrade.coffee
+++ b/omega-target-chromium-extension/src/module/upgrade.coffee
@@ -135,6 +135,10 @@ module.exports = (oldOptions, i18n) ->
             pattern: "localhost"
             conditionType: "BypassCondition"
           }
+          {
+            pattern: "192.168.*.*"
+            conditionType: "BypassCondition"
+          }
         ]
         profileType: "FixedProfile"
         name: exampleFixedProfileName


### PR DESCRIPTION
### What does this PR do?
- Improvement

Add 192.168.*.* to the default bypass list. This is because some non-technical home users cannot access their routers or optical modems after installing ZeroOmega.