### PR TITLE
Allow the use of transparent color for icon

### DIFF
--- a/omega-web/img/icons/draw_omega.js
+++ b/omega-web/img/icons/draw_omega.js
@@ -1,10 +1,13 @@
 globalThis.drawOmega = function (ctx, outerCircleColor, innerCircleColor) {
   ctx.globalCompositeOperation = "source-over";
-  ctx.fillStyle = outerCircleColor;
+  ctx.strokeStyle = outerCircleColor;
+
   ctx.beginPath();
-  ctx.arc(0.5, 0.5, 0.5, 0, Math.PI * 2, true);
+  ctx.lineWidth = 0.25;
+  ctx.arc(0.5, 0.5, 0.375, 0, Math.PI * 2, true);
+
   ctx.closePath();
-  ctx.fill();
+  ctx.stroke();
 
   if (innerCircleColor != null) {
     ctx.fillStyle = innerCircleColor;

--- a/omega-web/src/options.jade
+++ b/omega-web/src/options.jade
@@ -9,6 +9,7 @@ html(lang='en' ng-controller='MasterCtrl' ng-csp)
     link(rel='stylesheet' href='lib/ladda/ladda-themeless.min.css')
     link(rel='stylesheet' href='lib/shepherd.js/shepherd-theme-arrows.css')
     link(rel='stylesheet' href='css/options.css')
+    link(rel='icon' href='img/icons/omega-action.svg')
     style.om-style
       {{customCss}}
   body(style='display: none;' ng-style='{display: options ? "block" : "none"}')


### PR DESCRIPTION
### What does this PR do?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

(Note: Translations and typo fixes should be done on https://hosted.weblate.org/projects/switchyomega/ instead of PR.)

1. 允许使用透明颜色（例如： `rgba(0, 0, 0, 0)`） 作为图标颜色，如下图所示，**修改前**使用前面的颜色代码，设置页面图标能正常变成透明的，但是工具栏图标是**实心**的。
2. 设置页面添加 favicon， 让设置标签增加辩认度。
#### Screenshots (if applicable)
<img width="1172" height="584" alt="Screenshots" src="https://github.com/user-attachments/assets/2404fea4-4888-4e38-97ef-9a2884912ef7" />


