### PR TITLE
Allow specifying custom header values when fetching rule list

### DIFF
--- a/omega-locales/en_US/LC_MESSAGES/omega-web.po
+++ b/omega-locales/en_US/LC_MESSAGES/omega-web.po
@@ -694,6 +694,30 @@ msgstr ""
 "The rule list will be updated from this URL. If it is left blank, the "
 "following text will be parsed instead."
 
+msgid "options_group_ruleListHeaders"
+msgstr "Custom Headers"
+
+msgid "options_ruleListHeaderName"
+msgstr "Header Name"
+
+msgid "options_ruleListHeaderValue"
+msgstr "Header Value"
+
+msgid "options_ruleListHeaderNamePlaceholder"
+msgstr "e.g. Authorization"
+
+msgid "options_ruleListHeaderValuePlaceholder"
+msgstr "e.g. Bearer my-token"
+
+msgid "options_ruleListHeadersHelp"
+msgstr "You can specify custom HTTP headers to include when downloading the rule list. This is useful if, for example, the source requires authentication."
+
+msgid "options_deleteHeader"
+msgstr "Delete header"
+
+msgid "options_addHeader"
+msgstr "Add header"
+
 msgid "options_group_ruleListText"
 msgstr "Rule List Text"
 

--- a/omega-target/src/options.coffee
+++ b/omega-target/src/options.coffee
@@ -778,7 +778,12 @@ class Options
       url = OmegaPac.Profiles.updateUrl(profile)
       if url
         type_hints = OmegaPac.Profiles.updateContentTypeHints(profile)
-        fetchResult = @fetchUrl(url, opt_bypass_cache, type_hints)
+        headers = {}
+        if profile.headers
+          for header in profile.headers
+            # Being defensive here: filter out headers with empty names
+            headers[header.name] = header.value if header.name
+        fetchResult = @fetchUrl(url, headers, opt_bypass_cache, type_hints)
         results[key] = fetchResult.then((data) =>
           # Errors and unsuccessful response codes shoud have been already
           # rejected by fetchUrl and will not end up here.
@@ -805,11 +810,12 @@ class Options
   # Make an HTTP GET request to fetch the content of the url.
   # In base class, this method is not implemented and will always reject.
   # @param {string} url The name of the profiles,
+  # @param {?{}} headers Optional headers dictionary with name-value pairs
   # @param {?bool} opt_bypass_cache Do not read from the cache if true
   # @param {?string} opt_type_hints MIME type hints for downloaded content.
   # @returns {Promise<String>} The text content fetched from the url
   ###
-  fetchUrl: (url, opt_bypass_cache, opt_type_hints) ->
+  fetchUrl: (url, headers, opt_bypass_cache, opt_type_hints) ->
     Promise.reject new Error('not implemented')
 
   _replaceRefChanges: (fromName, toName, changes) ->

--- a/omega-web/src/omega/controllers/switch_profile.coffee
+++ b/omega-web/src/omega/controllers/switch_profile.coffee
@@ -458,3 +458,11 @@ angular.module('omega').controller 'SwitchProfileCtrl', ($scope, $rootScope,
         omegaTarget.state('web.switchGuide', 'shown')
         return if $scope.profile.rules.length == 0
         $script 'js/switch_profile_guide.js'
+
+  # == Custom Headers ==
+  $scope.addHeader = ->
+    $scope.attached.headers ?= []
+    $scope.attached.headers.push({name: '', value: ''})
+
+  $scope.removeHeader = (index) ->
+    $scope.attached.headers.splice(index, 1)

--- a/omega-web/src/partials/profile_switch.jade
+++ b/omega-web/src/partials/profile_switch.jade
@@ -170,7 +170,31 @@ div(ng-controller='SwitchProfileCtrl')
         label {{'options_group_ruleListUrl' | tr}}
         .width-limit.inline-form-control(input-group-clear type='url' model='attached.sourceUrl'
           style='vertical-align: middle')
-      p.help-block {{'options_ruleListUrlHelp' | tr}}
+        p.help-block {{'options_ruleListUrlHelp' | tr}}
+      .form-group
+        label {{'options_group_ruleListHeaders' | tr}}
+        .width-limit
+          .table-responsive(ng-if='attached.headers && attached.headers.length > 0')
+            table.table.table-bordered.table-condensed
+              thead
+                tr
+                  th {{'options_ruleListHeaderName' | tr}}
+                  th {{'options_ruleListHeaderValue' | tr}}
+                  th {{'options_conditionActions' | tr}}
+              tbody
+                tr(ng-repeat='header in attached.headers track by $index')
+                  td
+                    input.form-control(type='text' ng-model='header.name' placeholder="{{'options_ruleListHeaderNamePlaceholder' | tr}}" required)
+                  td
+                    input.form-control(type='text' ng-model='header.value' placeholder="{{'options_ruleListHeaderValuePlaceholder' | tr}}")
+                  td
+                    button.btn.btn-danger.btn-sm(type='button' title="{{'options_deleteHeader' | tr}}" ng-click='removeHeader($index)')
+                      span.glyphicon.glyphicon-trash
+          button.btn.btn-default.btn-sm(type='button' ng-click='addHeader()')
+            span.glyphicon.glyphicon-plus
+            = ' '
+            | {{'options_addHeader' | tr}}
+        p.help-block {{'options_ruleListHeadersHelp' | tr}}
     p
       button.btn.btn-default(ng-disabled='!attached.sourceUrl' ng-click='updateProfile(attached.name)'
           ladda='updatingProfile[attached.name]' data-spinner-color="#000000"


### PR DESCRIPTION
### What does this PR do?
- [ ] Bug fix
- [ ] Improvement
- [x] New feature

Currently you can specify a URL for the rule list of each switch profile, but said URL has to be publicly accessible. Due to the potentially-sensitive nature of the rule list, it would be nice to support authenticated sources too.

This PR adds the ability to add custom header values to the fetch, which allows the user to specify things like an [authorization header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Authorization). This would enable, for example, [fetching the rule list from a private gist or repository](https://github.com/orgs/community/discussions/22537#discussioncomment-3237244).

#### Compatibility

The feature is opt-in. No breaking changes.

#### Screenshots

<img width="1906" height="920" alt="New UI with custom headers" src="https://github.com/user-attachments/assets/91510bc9-0e0c-446d-a277-5cb2a9e31343" />

<img width="1384" height="1112" alt="Outgoing request with custom headers" src="https://github.com/user-attachments/assets/ff23ceaa-3bbe-4627-adac-3fcbb9b8fefa" />
