### PR TITLE
feat: support multiline patterns in switch rule conditions

### DIFF
--- a/omega-pac/src/conditions.coffee
+++ b/omega-pac/src/conditions.coffee
@@ -247,7 +247,11 @@ module.exports = exports =
 
     'UrlRegexCondition':
       abbrs: ['UR', 'URegex', 'UrlR', 'UrlRegex']
-      analyze: (condition) -> @safeRegex escapeSlash condition.pattern
+      analyze: (condition) ->
+        raw = condition.pattern.split(/[|\n]/)
+        parts = for p in raw when p.trim()
+          escapeSlash p.trim()
+        @safeRegex parts.join('|')
       match: (condition, request, cache) ->
         return cache.analyzed.test(request.url)
       compile: (condition, cache) ->
@@ -257,8 +261,9 @@ module.exports = exports =
       abbrs: ['U', 'UW', 'Url', 'UrlW', 'UWild', 'UWildcard', 'UrlWild',
               'UrlWildcard']
       analyze: (condition) ->
-        parts = for pattern in condition.pattern.split('|') when pattern
-          shExp2RegExp pattern, trimAsterisk: true
+        raw = condition.pattern.split(/[|\n]/)
+        parts = for pattern in raw when pattern.trim()
+          shExp2RegExp pattern.trim(), trimAsterisk: true
         @safeRegex parts.join('|')
       match: (condition, request, cache) ->
         return cache.analyzed.test(request.url)
@@ -267,7 +272,11 @@ module.exports = exports =
 
     'HostRegexCondition':
       abbrs: ['R', 'HR', 'Regex', 'HostR', 'HRegex', 'HostRegex']
-      analyze: (condition) -> @safeRegex escapeSlash condition.pattern
+      analyze: (condition) ->
+        raw = condition.pattern.split(/[|\n]/)
+        parts = for p in raw when p.trim()
+          escapeSlash p.trim()
+        @safeRegex parts.join('|')
       match: (condition, request, cache) ->
         return cache.analyzed.test(request.host)
       compile: (condition, cache) ->
@@ -277,7 +286,9 @@ module.exports = exports =
       abbrs: ['', 'H', 'W', 'HW', 'Wild', 'Wildcard', 'Host', 'HostW', 'HWild',
               'HWildcard', 'HostWild', 'HostWildcard']
       analyze: (condition) ->
-        parts = for pattern in condition.pattern.split('|') when pattern
+        raw = condition.pattern.split(/[|\n]/)
+        parts = for pattern in raw when pattern.trim()
+          pattern = pattern.trim()
           # Get the magical regex of this pattern. See
           # https://github.com/FelisCatus/SwitchyOmega/wiki/Host-wildcard-condition
           # for the magic.
@@ -684,4 +695,5 @@ module.exports = exports =
         condition.startHour = 0 unless 0 <= condition.startHour < 24
         condition.endHour = 0 unless 0 <= condition.endHour < 24
         condition
+
     # coffeelint: enable=missing_fat_arrows

--- a/omega-web/src/omega/controllers/switch_profile.coffee
+++ b/omega-web/src/omega/controllers/switch_profile.coffee
@@ -192,12 +192,16 @@ angular.module('omega').controller 'SwitchProfileCtrl', ($scope, $rootScope,
       rule.condition.pattern = ''
     $scope.profile.rules.push rule
 
+  $scope.isMultiline = (pattern) ->
+    pattern and pattern.indexOf('\n') >= 0
+
   $scope.validateCondition = (condition, pattern) ->
     if condition.conditionType.indexOf('Regex') >= 0
-      try
-        new RegExp(pattern)
-      catch _
-        return false
+      for line in pattern.split(/[|\n]/) when line.trim()
+        try
+          new RegExp(line.trim())
+        catch _
+          return false
     return true
 
   $scope.conditionHasWarning = (condition) ->

--- a/omega-web/src/partials/profile_switch.jade
+++ b/omega-web/src/partials/profile_switch.jade
@@ -94,8 +94,16 @@ div(ng-controller='SwitchProfileCtrl')
                 label.checkbox-inline(ng-repeat='selected in getWeekdayList(rule.condition) track by $index')
                   input(type='checkbox' ng-model='selected' ng-change='updateDay(rule.condition, $index, selected)')
                   = '{{"options_weekDayShort_" + $index | tr}} '
-              input.form-control(ng-model='rule.condition.pattern' ng-switch-default required
-                ui-validate='{pattern: "validateCondition(rule.condition, $value)"}')
+              span.input-group(ng-switch-default)
+                textarea.form-control.monospace(ng-model='rule.condition.pattern' required
+                  rows='{{rule._expanded ? 10 : 1}}'
+                  ng-click='!rule._expanded && isMultiline(rule.condition.pattern) && (rule._expanded = true)'
+                  ng-keydown='!rule._expanded && $event.keyCode === 13 && $event.preventDefault()'
+                  ng-style='{cursor: !rule._expanded && isMultiline(rule.condition.pattern) ? "pointer" : "auto", resize: "none", overflow: rule._expanded ? "auto" : "hidden", height: rule._expanded ? "auto" : "34px"}'
+                  ui-validate='{pattern: "validateCondition(rule.condition, $value)"}')
+                span.input-group-btn
+                  button.btn.btn-default(type='button' ng-click='rule._expanded = !rule._expanded')
+                    span.glyphicon(ng-class='rule._expanded ? "glyphicon-chevron-up" : "glyphicon-chevron-down"')
             td.switch-rule-row-target
               div(omega-profile-select='options | profiles:profile' ng-model='rule.profileName'
                 disp-name='dispNameFilter' options='options'


### PR DESCRIPTION
## Summary

Allow users to enter multiple patterns in a single switch rule condition, separated by newlines (in addition to the existing pipe `|` separator).

## Changes

**omega-pac/src/conditions.coffee**
- `HostWildcardCondition`, `UrlWildcardCondition`, `HostRegexCondition`, `UrlRegexCondition` now split patterns by both `|` and newline `\n`

**omega-web/src/partials/profile_switch.jade**
- Replace single-line `input` with an expandable `textarea` (1 row collapsed, 10 rows expanded)
- Toggle button to expand/collapse
- Single-line mode blocks Enter key; auto-expands on click when multiline content exists

**omega-web/src/omega/controllers/switch_profile.coffee**
- Add `isMultiline()` helper
- `validateCondition` validates each line independently for regex types

## Notes

The pre-existing SOCKS5 test failure (`should return special compatible result for SOCKS5`) exists on master and is unrelated to this change.