### PR TITLE
Add option to disable sending DNS requests via SOCKS proxy

### DIFF
--- a/omega-locales/en_US/LC_MESSAGES/omega-web.po
+++ b/omega-locales/en_US/LC_MESSAGES/omega-web.po
@@ -641,6 +641,12 @@ msgstr "Use the proxy above for all protocols."
 msgid "options_proxy_expand"
 msgstr "Show Advanced"
 
+msgid "options_proxy_proxyDNS"
+msgstr "Proxy DNS requests via SOCKS proxy."
+
+msgid "options_proxy_proxyDNSHelp"
+msgstr "This should be disabled if you use DNS-over-HTTPS in Firefox-based browsers."
+
 msgid "options_group_bypassList"
 msgstr "Bypass List"
 

--- a/omega-target-chromium-extension/src/js/omega_webext_proxy_script.js
+++ b/omega-target-chromium-extension/src/js/omega_webext_proxy_script.js
@@ -48,8 +48,9 @@ FindProxyForURL = (function () {
             // https://dxr.mozilla.org/mozilla-central/rev/ffe6cc09ccf38cca6f0e727837bbc6cb722d1e71/toolkit/components/extensions/ProxyScriptContext.jsm#51
             proxyInfo.type = 'socks';
             // Enable SOCKS5 remote DNS.
-            // TODO(catus): Maybe allow the users to configure this?
-            proxyInfo.proxyDNS = true;
+            if (profile.proxyDNS) {
+              proxyInfo.proxyDNS = true;
+            }
           }
           if (auth) {
             proxyInfo.username = auth.username;

--- a/omega-target-chromium-extension/src/module/proxy/proxy_impl_firefox.coffee
+++ b/omega-target-chromium-extension/src/module/proxy/proxy_impl_firefox.coffee
@@ -48,7 +48,7 @@ class FirefoxProxyImpl extends ProxyImpl
         blobUrl = URL.createObjectURL(blob)
         browser.proxy.settings.set({
           value: {
-            proxyDNS: true,
+            proxyDNS: profile.proxyDNS,
             proxyType: 'autoConfig',
             autoConfigUrl: blobUrl
           }
@@ -81,7 +81,7 @@ class FirefoxProxyImpl extends ProxyImpl
         if Array.isArray(result)
           proxy = result[2]
           auth = result[3]
-          return @proxyInfo(proxy, auth) if proxy
+          return @proxyInfo(proxy, auth, profile.proxyDNS) if proxy
           next = result[0]
         else if result.profileName
           next = OmegaPac.Profiles.nameAsKey(result.profileName)
@@ -93,7 +93,7 @@ class FirefoxProxyImpl extends ProxyImpl
     ))
   onError: (error) ->
     @log.error(error)
-  proxyInfo: (proxy, auth) ->
+  proxyInfo: (proxy, auth, proxyDNS) ->
     proxyInfo =
       type: proxy.scheme
       host: proxy.host
@@ -108,9 +108,8 @@ class FirefoxProxyImpl extends ProxyImpl
         # HTTP proxy auth must be handled via webRequest.onAuthRequired.
         proxyInfo.username = auth.username
         proxyInfo.password = auth.password
-    if proxyInfo.type == 'socks'
+    if proxyInfo.type == 'socks' and proxyDNS
       # Enable SOCKS remote DNS.
-      # TODO(catus): Maybe allow the users to configure this?
       proxyInfo.proxyDNS = true
 
     # TODO(catus): Maybe allow proxyDNS for socks4? Server may support SOCKS4a.

--- a/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
+++ b/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
@@ -45,7 +45,7 @@ class ListenerProxyImpl extends ProxyImpl
         if Array.isArray(result)
           proxy = result[2]
           auth = result[3]
-          return @proxyInfo(proxy, auth) if proxy
+          return @proxyInfo(proxy, auth, profile.proxyDNS) if proxy
           next = result[0]
         else if result.profileName
           next = OmegaPac.Profiles.nameAsKey(result.profileName)
@@ -57,7 +57,7 @@ class ListenerProxyImpl extends ProxyImpl
     ))
   onError: (error) ->
     @log.error(error)
-  proxyInfo: (proxy, auth) ->
+  proxyInfo: (proxy, auth, proxyDNS) ->
     proxyInfo =
       type: proxy.scheme
       host: proxy.host
@@ -72,9 +72,8 @@ class ListenerProxyImpl extends ProxyImpl
         # HTTP proxy auth must be handled via webRequest.onAuthRequired.
         proxyInfo.username = auth.username
         proxyInfo.password = auth.password
-    if proxyInfo.type == 'socks'
+    if proxyInfo.type == 'socks' and proxyDNS
       # Enable SOCKS remote DNS.
-      # TODO(catus): Maybe allow the users to configure this?
       proxyInfo.proxyDNS = true
 
     # TODO(catus): Maybe allow proxyDNS for socks4? Server may support SOCKS4a.

--- a/omega-web/src/omega/controllers/fixed_profile.coffee
+++ b/omega-web/src/omega/controllers/fixed_profile.coffee
@@ -21,6 +21,8 @@ angular.module('omega').controller 'FixedProfileCtrl', ($scope, $modal,
 
   $scope.showAdvanced = false
 
+  $scope.proxyDNS = $scope.profile.proxyDNS ? true
+
   $scope.optionsForScheme = {}
   for scheme in $scope.urlSchemes
     defaultLabel =
@@ -94,6 +96,12 @@ angular.module('omega').controller 'FixedProfileCtrl', ($scope, $modal,
     $scope.bypassList = (item.pattern for item in list).join('\n')
 
   $scope.$watch 'profile.bypassList', onBypassListChange, true
+
+  onProxyDNSChange = (proxyDNS) ->
+    $scope.profile.proxyDNS = proxyDNS
+    $scope.proxyDNS = proxyDNS
+
+  $scope.$watch 'proxyDNS', onProxyDNSChange, true
 
   $scope.$watch 'bypassList', (bypassList, oldList) ->
     return if not bypassList? or bypassList == oldList

--- a/omega-web/src/partials/profile_fixed.jade
+++ b/omega-web/src/partials/profile_fixed.jade
@@ -35,6 +35,14 @@ div(ng-controller='FixedProfileCtrl')
             td(colspan='7')
               button.btn.btn-link(ng-click='showAdvanced = true')
                 | #[span.glyphicon.glyphicon-chevron-down] {{'options_proxy_expand' | tr}}
+        tbody
+          tr
+            td(colspan='7')
+              div.checkbox
+                label
+                  input(type='checkbox' ng-model='proxyDNS')
+                  span {{'options_proxy_proxyDNS' | tr}}
+                p.help-block(omega-html="'options_proxy_proxyDNSHelp' | tr")
   section.settings-group
     h3 {{'options_group_bypassList' | tr}}
     p.help-block {{'options_bypassListHelp' | tr}}


### PR DESCRIPTION
### What does this PR do?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

Opening sites via SOCKS5 proxy with "auto switch" enabled fails when DNS-over-HTTPS is used in Firefox. This PR adds an option to disable sending the DNS requests via proxy. This can cause a DNS leak, but if a user has configured a trusted DoH server in browser - a leak should not be a problem.

Checkbox is enabled by default - so the default behavior is not changed.

This option was mentioned by @FelisCatus in sources earlier:

> TODO(catus): Maybe allow the users to configure this?


#### Compatibility

Is this PR compatible with old versions? Can users simply upgrade the extension?
Yes

#### Screenshots (if applicable)
<img width="1169" height="396" alt="image" src="https://github.com/user-attachments/assets/c0cf9427-77f8-49c5-b746-016b7a427c4f" />

---

After creating the PR:

- Please make sure the CircleCI test passes. Feel free to add more commits for
bug or style fixes.
- Any merge conflicts should be fixed on *your* side. Prefer rebasing to merging.
- Allow some time for project maintainers to review and merge the change.
- New features & behavior changes are subject to discussion. Please understand
that project maintainers may reject new features, or request changes.
