### PR TITLE
Append popup-added conditions to the end of switch rules

### DIFF
--- a/omega-target-chromium-extension/src/coffee/omega_target_web.coffee
+++ b/omega-target-chromium-extension/src/coffee/omega_target_web.coffee
@@ -140,8 +140,8 @@ angular.module('omegaTarget', []).factory 'omegaTarget', ($q) ->
       callBackgroundNoReply('applyProfile', name)
     addTempRule: (domain, profileName, toggle) ->
       callBackground('addTempRule', domain, profileName, toggle)
-    addCondition: (condition, profileName) ->
-      callBackground('addCondition', condition, profileName)
+    addCondition: (condition, profileName, addToBottom) ->
+      callBackground('addCondition', condition, profileName, addToBottom)
     addProfile: (profile) ->
       callBackground('addProfile', profile).then omegaTarget.refresh
     setDefaultProfile: (profileName, defaultProfileName) ->

--- a/omega-target-chromium-extension/src/js/omega_target_popup.js
+++ b/omega-target-chromium-extension/src/js/omega_target_popup.js
@@ -71,8 +71,12 @@ OmegaTargetPopup = {
     callBackgroundNoReply('setDefaultProfile',
       [profileName, defaultProfileName], cb);
   },
-  addCondition: function(condition, profileName, cb){
-    callBackground('addCondition', [condition, profileName], cb)
+  addCondition: function(condition, profileName, addToBottom, cb){
+    if (typeof addToBottom == 'function') {
+      cb = addToBottom;
+      addToBottom = null;
+    }
+    callBackground('addCondition', [condition, profileName, addToBottom], cb)
   },
   getTempRules: function(cb){
     callBackground('getTempRules', [], cb);

--- a/omega-target/src/options.coffee
+++ b/omega-target/src/options.coffee
@@ -998,9 +998,10 @@ class Options
   # Add a condition to the current active switch profile.
   # @param {Object.<String,{}>} cond The condition to add
   # @param {string>} profileName The name of the result profile of the rule.
+  # @param {boolean=} addToBottom Whether to append the rule to the end.
   # @returns {Promise} A promise which is fulfilled when the condition is saved.
   ###
-  addCondition: (condition, profileName) ->
+  addCondition: (condition, profileName, addToBottom) ->
     @log.method('Options#addCondition', this, arguments)
     return Promise.resolve() if not @_currentProfileName
     profile = OmegaPac.Profiles.byName(@_currentProfileName, @_options)
@@ -1022,7 +1023,7 @@ class Options
           break
 
 
-      if @_options['-addConditionsToBottom']
+      if addToBottom ? @_options['-addConditionsToBottom']
         profile.rules.push({
           condition: cond
           profileName: profileName

--- a/omega-web/src/coffee/popup.coffee
+++ b/omega-web/src/coffee/popup.coffee
@@ -163,7 +163,7 @@ module.controller 'PopupCtrl', ($scope, $window, $q, omegaTarget,
       refresh()
   
   $scope.addCondition = (condition, profileName) ->
-    omegaTarget.addCondition(condition, profileName).then ->
+    omegaTarget.addCondition(condition, profileName, true).then ->
       omegaTarget.state('lastProfileNameForCondition', profileName)
       refresh()
 
@@ -174,7 +174,7 @@ module.controller 'PopupCtrl', ($scope, $window, $q, omegaTarget,
         conditionType: 'HostWildcardCondition'
         pattern: domain
       })
-    omegaTarget.addCondition(conditions, profileName).then ->
+    omegaTarget.addCondition(conditions, profileName, true).then ->
       omegaTarget.state('lastProfileNameForCondition', profileName)
       refresh()
 

--- a/omega-web/src/popup/network/js/url.js
+++ b/omega-web/src/popup/network/js/url.js
@@ -316,7 +316,7 @@ export const initUrlCellDetail = async (cell) => {
     OmegaTargetPopup.addCondition([{
       conditionType: 'HostWildcardCondition',
       pattern
-    }], profileName, ()=>{
+    }], profileName, true, ()=>{
       OmegaTargetPopup.setState('lastProfileNameForCondition', profileName, ()=>{
         Toastify({
           text: "Add condition success",


### PR DESCRIPTION
### What does this PR do?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

This PR updates popup-added switch rules so they are appended to the end of the rule list instead of being inserted at the top.

Switch rules are matched from top to bottom, so newly added broader conditions should not take priority over existing, more specific rules.

Example:
- Existing rule: `*.gemini.google.com` -> `xxx`
- New popup-added rule: `*.google.com` -> `yyy`

If the new rule is inserted at the top, `*.google.com` can shadow the existing `*.gemini.google.com` rule. Appending popup-added rules to the bottom preserves the priority of existing rules while still adding the new condition.

Implementation details:
- Adds an optional `addToBottom` parameter to `Options#addCondition`.
- Keeps the existing `-addConditionsToBottom` option as the default behavior for callers that do not pass the new parameter.
- Passes `addToBottom = true` from popup condition entry points:
  - normal popup “Add condition”
  - request error domain list “Add condition”
  - network request detail “Add condition”

#### Compatibility

This PR is compatible with old versions. Users can upgrade normally.

There are no data format or migration changes. The only UX behavior change is that conditions added from popup entry points are now appended to the bottom of the switch rule list, preserving existing rule priority. Other callers keep the previous default behavior.

#### Screenshots (if applicable)
<img width="414" height="352" alt="image" src="https://github.com/user-attachments/assets/9d34b9e2-fb41-491d-bdae-bda6e6dd2593" />

Not applicable.