### PR TITLE
[codex] Keep auth preflight rule internal

### DIFF
--- a/omega-target-chromium-extension/src/module/proxy/proxy_impl_settings.coffee
+++ b/omega-target-chromium-extension/src/module/proxy/proxy_impl_settings.coffee
@@ -12,12 +12,14 @@ getFirstAuthProfile = (profile, options) ->
     _profile = OmegaPac.Profiles.byName(profileName, options)
     return _profile if _profile?.auth
 
-addAuthPreflightRule = (profile, options) ->
+withAuthPreflightRule = (profile, options) ->
   return unless profile.profileType is 'SwitchProfile'
-  return unless profile.rules or profile.rules.length is 0
+  return unless profile.rules?.length > 0
   authProfile = getFirstAuthProfile(profile, options)
   return unless authProfile
-  profile.rules.unshift({
+  # The auth probe rule is internal; keep it out of user-visible profiles.
+  preflightProfile = JSON.parse(JSON.stringify(profile))
+  preflightProfile.rules.unshift({
     "condition": {
       "conditionType": "HostWildcardCondition"
       "pattern": notExistentWebsite
@@ -25,7 +27,10 @@ addAuthPreflightRule = (profile, options) ->
     "isPreflightRule": true
     "profileName": authProfile.name
   })
-  return authProfile
+  return {
+    authProfile: authProfile
+    profile: preflightProfile
+  }
 
 class SettingsProxyImpl extends ProxyImpl
   @isSupported: -> chrome?.proxy?.settings?
@@ -55,7 +60,10 @@ class SettingsProxyImpl extends ProxyImpl
       config = @_fixedProfileConfig(profile)
     else
       config['mode'] = 'pac_script'
-      authProfile = addAuthPreflightRule(profile, options)
+      authPreflight = withAuthPreflightRule(profile, options)
+      if authPreflight
+        authProfile = authPreflight.authProfile
+        profile = authPreflight.profile
       config['pacScript'] =
         mandatory: true
         data: @getProfilePacScript(profile, meta, options)
@@ -66,13 +74,6 @@ class SettingsProxyImpl extends ProxyImpl
         fetch("https://" + notExistentWebsite).catch(-> authProfile)
       chrome.proxy.settings.get {}, @_proxyChangeListener
       return
-    ).finally(->
-      if authProfile
-        profile.rules.forEach((rule, index) ->
-          if rule.isPreflightRule
-            profile.rules.splice(index, 1)
-        )
-        profile.rules
     )
   _fixedProfileConfig: (profile) ->
     config = {}

--- a/omega-target-chromium-extension/test/proxy_impl_settings.coffee
+++ b/omega-target-chromium-extension/test/proxy_impl_settings.coffee
@@ -1,0 +1,71 @@
+chai = require 'chai'
+should = chai.should()
+
+OmegaTarget = require 'omega-target'
+Promise = OmegaTarget.Promise
+SettingsProxyImpl =
+  require '../src/module/proxy/proxy_impl_settings'
+
+describe 'SettingsProxyImpl', ->
+  beforeEach ->
+    @originalChrome = global.chrome
+    @originalFetch = global.fetch
+    global.chrome =
+      runtime: {}
+      proxy:
+        settings:
+          set: (details, callback) -> callback()
+          get: -> null
+    global.fetch = -> Promise.reject(new Error('skip network'))
+
+  afterEach ->
+    global.chrome = @originalChrome
+    global.fetch = @originalFetch
+
+  it 'should not leak auth preflight rules into the applied profile', (done) ->
+    impl = new SettingsProxyImpl(error: -> null)
+    profile =
+      name: 'auto'
+      profileType: 'SwitchProfile'
+      revision: '1'
+      defaultProfileName: 'direct'
+      rules: [
+        {
+          condition:
+            conditionType: 'HostWildcardCondition'
+            pattern: '*.example.com'
+          profileName: 'proxy'
+        }
+      ]
+    authProfile =
+      name: 'proxy'
+      profileType: 'FixedProfile'
+      revision: '1'
+      fallbackProxy:
+        scheme: 'http'
+        host: '127.0.0.1'
+        port: 8080
+      auth:
+        all:
+          username: 'u'
+          password: 'p'
+    options =
+      '+auto': profile
+      '+proxy': authProfile
+
+    pacProfile = null
+    impl.setProxyAuth = -> Promise.resolve()
+    impl.getProfilePacScript = (profileForPac, meta) ->
+      pacProfile = profileForPac
+      meta.should.equal(profile)
+      return 'function FindProxyForURL(){return "DIRECT";}'
+
+    impl.applyProfile(profile, profile, options).then( ->
+      profile.rules.length.should.equal(1)
+      should.not.exist profile.rules[0].isPreflightRule
+      pacProfile.should.not.equal(profile)
+      pacProfile.rules.length.should.equal(2)
+      pacProfile.rules[0].isPreflightRule.should.equal(true)
+      pacProfile.rules[1].should.eql(profile.rules[0])
+      done()
+    ).catch(done)


### PR DESCRIPTION
## What changed

Fixes #214.

The Chrome settings proxy backend used to insert the internal proxy-auth preflight rule directly into the active SwitchProfile before generating the PAC script, then remove it in `finally`. That made the internal `preflight-auth.non-existent-website.zzzzzzzzeroomega.zero` rule observable by other code while the profile was being applied.

This changes the preflight path to clone the profile first, add the probe rule only to that clone, and generate the PAC script from the clone. The user's profile object is never mutated by the internal auth probe.

## Why

The preflight rule is an implementation detail for triggering proxy authentication. It should not be visible to the options UI, sync/storage code, temp-rule state, or any rule-adding flow. Keeping it out of the real profile prevents it from leaking into Auto Switch rules.

## Validation

- `coffeelint.cmd src/module/proxy/proxy_impl_settings.coffee test/proxy_impl_settings.coffee` from `omega-target-chromium-extension`
- `omega-target-chromium-extension/test/proxy_impl_settings.coffee`: 1 passing